### PR TITLE
Example Update: Make input functions virtual #501

### DIFF
--- a/Source/ALSExtras/Public/AlsCharacterExample.h
+++ b/Source/ALSExtras/Public/AlsCharacterExample.h
@@ -89,31 +89,31 @@ protected:
 	virtual void SetupPlayerInputComponent(UInputComponent* Input) override;
 
 private:
-	void Input_OnLookMouse(const FInputActionValue& ActionValue);
+	virtual void Input_OnLookMouse(const FInputActionValue& ActionValue);
 
-	void Input_OnLook(const FInputActionValue& ActionValue);
+	virtual void Input_OnLook(const FInputActionValue& ActionValue);
 
-	void Input_OnMove(const FInputActionValue& ActionValue);
+	virtual void Input_OnMove(const FInputActionValue& ActionValue);
 
-	void Input_OnSprint(const FInputActionValue& ActionValue);
+	virtual void Input_OnSprint(const FInputActionValue& ActionValue);
 
-	void Input_OnWalk();
+	virtual void Input_OnWalk();
 
-	void Input_OnCrouch();
+	virtual void Input_OnCrouch();
 
-	void Input_OnJump(const FInputActionValue& ActionValue);
+	virtual void Input_OnJump(const FInputActionValue& ActionValue);
 
-	void Input_OnAim(const FInputActionValue& ActionValue);
+	virtual void Input_OnAim(const FInputActionValue& ActionValue);
 
-	void Input_OnRagdoll();
+	virtual void Input_OnRagdoll();
 
-	void Input_OnRoll();
+	virtual void Input_OnRoll();
 
-	void Input_OnRotationMode();
+	virtual void Input_OnRotationMode();
 
-	void Input_OnViewMode();
+	virtual void Input_OnViewMode();
 
-	void Input_OnSwitchShoulder();
+	virtual void Input_OnSwitchShoulder();
 
 	// Debug
 


### PR DESCRIPTION
## What
* Makes Example Character's `Input_*` functions virtual so they can be overridden by child classes

## Why
* The example character is a good place to start as a child for getting going. It is common to need to change things, as such these Input functions can be virtual so they can be overridden.